### PR TITLE
Prepare release 1.1.0

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,2 +1,3 @@
 - Test and implement all known WS Commands
 - Implement all AWS Commands
+- Find out how configuration for time, sensivity, open angle, open-time, ...

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+Version 1.1.0 (2024-01-05)
+- Added methods to get current doors Software Version and Serial Number
+- Implemented option to get events unknown/without pet
+- Fixed Event object to have UTC as timezone
+
 Version 1.0.1 (2023-12-23)
 - Fixed error on AWS Token renewal (Issue: https://github.com/p0l0/hapetwalk/issues/7)
 

--- a/pypetwalk/__version__.py
+++ b/pypetwalk/__version__.py
@@ -1,3 +1,3 @@
 """pypetwalk version."""
 
-__version__ = "1.0.1"
+__version__ = "1.1.0"

--- a/pypetwalk/aws/event.py
+++ b/pypetwalk/aws/event.py
@@ -1,7 +1,7 @@
 """pypetwalk is a Python library to communicate with the petWALK.control module."""
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from pypetwalk.const import PET_SPECIES_MAPPING
 
@@ -99,7 +99,9 @@ class Event:
 
     @date.setter
     def date(self, date: str) -> None:
-        self._date = datetime.strptime(date, "%Y-%m-%dT%H:%M:%S")
+        # Provided date ist UTC, but format has no timezone information
+        parsed = datetime.strptime(date, "%Y-%m-%dT%H:%M:%S")
+        self._date = parsed.replace(tzinfo=timezone.utc)
 
     @property
     def rfid_index(self) -> int | None:

--- a/pypetwalk/const.py
+++ b/pypetwalk/const.py
@@ -85,3 +85,6 @@ EVENT_TYPE_ONLINE: Final = "online"
 EVENT_TYPE_OFFLINE: Final = "offline"
 EVENT_TYPE_ON: Final = "on"
 EVENT_TYPE_OFF: Final = "off"
+
+UNKNOWN_PET_ID: Final = "None"
+UNKNOWN_PET_NAME: Final = "Unknown"

--- a/pypetwalk/pypetwalk.py
+++ b/pypetwalk/pypetwalk.py
@@ -112,6 +112,26 @@ class PyPetWALK:
         except (IndexError, KeyError) as ex:
             raise PyPetWALKInvalidResponse from ex
 
+    async def get_sw_version(self) -> str:
+        """Return the Device Name for our Door."""
+        try:
+            device_info = await self.get_device_info()
+            sw_version = device_info["responses"][0]["DeviceInfo"][0][
+                "sw_version"
+            ].split(".")
+            sw_version.pop(0)
+            return ".".join(sw_version)
+        except (IndexError, KeyError) as ex:
+            raise PyPetWALKInvalidResponse from ex
+
+    async def get_serial_number(self) -> str:
+        """Return the Device Name for our Door."""
+        try:
+            device_info = await self.get_device_info()
+            return device_info["responses"][0]["DeviceInfo"][0]["serial"]  # type: ignore[no-any-return] # noqa: E501
+        except (IndexError, KeyError) as ex:
+            raise PyPetWALKInvalidResponse from ex
+
     async def get_available_pets(self) -> list[Pet]:
         """Return list of available Pets."""
         try:

--- a/pypetwalk/pypetwalk.py
+++ b/pypetwalk/pypetwalk.py
@@ -22,6 +22,8 @@ from .const import (
     AWS_URL,
     AWS_USER_POOL_ID,
     EVENT_TYPE_OPEN,
+    UNKNOWN_PET_ID,
+    UNKNOWN_PET_NAME,
     WS_PORT,
 )
 from .exceptions import PyPetWALKInvalidResponse, PyPetWALKInvalidResponseValue
@@ -132,7 +134,7 @@ class PyPetWALK:
         except (IndexError, KeyError) as ex:
             raise PyPetWALKInvalidResponse from ex
 
-    async def get_available_pets(self) -> list[Pet]:
+    async def get_available_pets(self, include_unknown: bool = False) -> list[Pet]:
         """Return list of available Pets."""
         try:
             device_info = await self.get_device_info()
@@ -150,6 +152,15 @@ class PyPetWALK:
                         created=pet[4],
                     )
                 )
+
+            if include_unknown:
+                pets.append(
+                    Pet(
+                        pet_id=UNKNOWN_PET_ID,
+                        name=UNKNOWN_PET_NAME,
+                    )
+                )
+
             return pets
         except (IndexError, KeyError) as ex:
             raise PyPetWALKInvalidResponse from ex
@@ -161,10 +172,14 @@ class PyPetWALK:
         status: dict[str, Event] = {}
         for entry in timeline:
             event = Event(entry)
-            if event.event_type != EVENT_TYPE_OPEN or event.pet is None:
+            if event.event_type != EVENT_TYPE_OPEN:
                 continue
 
-            pet_id = event.pet.id
+            if event.pet is not None:
+                pet_id = event.pet.id
+            else:
+                pet_id = UNKNOWN_PET_ID
+
             if pet_id not in status or status[pet_id].date < event.date:
                 status[pet_id] = event
                 continue


### PR DESCRIPTION
Prepare release 1.1.0 with following changes:

- Added methods to get current doors Software Version and Serial Number
- Implemented option to get events unknown/without pet
- Fixed Event object to have UTC as timezone